### PR TITLE
Silent fail non swipe holders

### DIFF
--- a/library/src/main/java/atownsend/swipeopenhelper/SwipeOpenItemTouchHelper.java
+++ b/library/src/main/java/atownsend/swipeopenhelper/SwipeOpenItemTouchHelper.java
@@ -859,7 +859,6 @@ public class SwipeOpenItemTouchHelper extends RecyclerView.ItemDecoration
     if (holder instanceof SwipeOpenViewHolder) {
       return holder;
     }
-    Log.w(TAG, "View Holders must implement SwipeOpenViewHolder to handle swipe-to-open.");
     return null;
   }
 

--- a/library/src/main/java/atownsend/swipeopenhelper/SwipeOpenItemTouchHelper.java
+++ b/library/src/main/java/atownsend/swipeopenhelper/SwipeOpenItemTouchHelper.java
@@ -857,10 +857,10 @@ public class SwipeOpenItemTouchHelper extends RecyclerView.ItemDecoration
     }
     RecyclerView.ViewHolder holder = recyclerView.getChildViewHolder(child);
     if (holder instanceof SwipeOpenViewHolder) {
-      return recyclerView.getChildViewHolder(child);
-    } else {
-      throw new IllegalStateException("Swiped View Holders must implement SwipeOpenViewHolder");
+      return holder;
     }
+    Log.w(TAG, "View Holders must implement SwipeOpenViewHolder to handle swipe-to-open.");
+    return null;
   }
 
   /**
@@ -874,7 +874,7 @@ public class SwipeOpenItemTouchHelper extends RecyclerView.ItemDecoration
       return false;
     }
     final RecyclerView.ViewHolder vh = findSwipedView(motionEvent);
-    if (vh == null || !(vh instanceof SwipeOpenViewHolder)) {
+    if (vh == null) {
       return false;
     }
 


### PR DESCRIPTION
Swiping non-SwipeOpenViewHolder's will now silently fail the swipe instead of causing an exception.
